### PR TITLE
fix: double announements on the channels

### DIFF
--- a/lib/bot.js
+++ b/lib/bot.js
@@ -102,7 +102,7 @@ class Bot {
         const user = this.lookup.get(users[x]);
         const userName = user ? user.profile.real_name : 'UNKNOWN_USER';
         found = true;
-        retVal += `> ${userName}: ${oooUser.message}\n`;
+        retVal += `> *${userName}*: _${oooUser.message}_\n`;
       }
     }
 
@@ -188,25 +188,28 @@ class Bot {
         logger.info(`Next announcement in: ${moment.duration(nextInterval).humanize()}`);
         this.nextAnnounce = setTimeout(() => {
           logger.info('Announcing on schedule to:', this.config.app.announce.channels);
-          // find the channel id
-          let channelIds = {};
-          this.lookup.forEach((item) => {
-            // only announce on channel or group
-            if (
-              (item.is_channel || item.is_group) && // channel or group
-              self.config.app.announce.channels.indexOf(item.name) !== -1
-            ) {
-              channelIds[item.name] = item.id;
-            }
-          });
-          // loop through channels and announce
-          Object.keys(channelIds).forEach((channel) => {
-            let channelId = channelIds[channel];
-            // send message to channel
-            logger.info(`Announcing offline on channel: ${channel}(${channelId})`);
-            self.bot.say({
-              channel: channelId,
-              text: self.announceOffline()
+           // loop through channels and announce
+          self.config.app.announce.channels.forEach((channel) => {
+            // find the channel id
+            this.lookup.forEach((item) => {
+              // only announce on channel or group
+              if (
+                (item.is_channel || item.is_group) && // channel or group
+                item.name === channel
+              ) {
+                // Check to see if your a member of the channel
+                // if you can see a group, you're in the group
+                if (item.is_channel && !item.is_member) {
+                  logger.error(`Cannot announce as you are not a member: ${item.name}(${item.id})`);
+                } else {
+                  // send message to channel
+                  logger.info(`Announcing offline on channel: ${item.name}(${item.id})`);
+                  self.bot.say({
+                    channel: item.id,
+                    text: self.announceOffline()
+                  });
+                }
+              }
             });
           });
           self.startAnnounceLoop();

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -188,22 +188,25 @@ class Bot {
         logger.info(`Next announcement in: ${moment.duration(nextInterval).humanize()}`);
         this.nextAnnounce = setTimeout(() => {
           logger.info('Announcing on schedule to:', this.config.app.announce.channels);
+          // find the channel id
+          let channelIds = {};
+          this.lookup.forEach((item) => {
+            // only announce on channel or group
+            if (
+              (item.is_channel || item.is_group) && // channel or group
+              self.config.app.announce.channels.indexOf(item.name) !== -1
+            ) {
+              channelIds[item.name] = item.id;
+            }
+          });
           // loop through channels and announce
           self.config.app.announce.channels.forEach((channel) => {
-            // find the channel id
-            this.lookup.forEach((item) => {
-              // only announce on channel or group
-              if (
-                (item.is_channel || item.is_group) && // channel or group
-                self.config.app.announce.channels.indexOf(item.name) !== -1
-              ) {
-                // send message to channel
-                logger.info(`Announcing offline on channel: ${item.name}(${item.id})`);
-                self.bot.say({
-                  channel: item.id,
-                  text: self.announceOffline()
-                });
-              }
+            let channelId = channelIds[channel];
+            // send message to channel
+            logger.info(`Announcing offline on channel: ${channel}(${channelId})`);
+            self.bot.say({
+              channel: channelId,
+              text: self.announceOffline()
             });
           });
           self.startAnnounceLoop();

--- a/lib/bot.js
+++ b/lib/bot.js
@@ -200,7 +200,7 @@ class Bot {
             }
           });
           // loop through channels and announce
-          self.config.app.announce.channels.forEach((channel) => {
+          Object.keys(channelIds).forEach((channel) => {
             let channelId = channelIds[channel];
             // send message to channel
             logger.info(`Announcing offline on channel: ${channel}(${channelId})`);

--- a/test/bot.test.js
+++ b/test/bot.test.js
@@ -30,18 +30,18 @@ test('Bot: Find ms until next time', (assert) => {
 
   // rounding because we are rarely on the minute
   assert.equal(
-    Math.round(bot.msTillNextTime(times) / 100000), 36,
+    Math.ceil(bot.msTillNextTime(times) / 100000), 36,
     'Next time should be about an hour away'
   );
 
   times.splice(4, 1); // remove one hour time
   assert.equal(
-    Math.round(bot.msTillNextTime(times) / 100000), 72,
+    Math.ceil(bot.msTillNextTime(times) / 100000), 72,
     'Next time should be about two hours away'
   );
 
   assert.equal(
-    Math.round(bot.msTillNextTime(times.slice(0, 4)) / 1000000), 72,
+    Math.ceil(bot.msTillNextTime(times.slice(0, 4)) / 1000000), 72,
     'Next time should be about 20 hours away'
   );
 


### PR DESCRIPTION
## What's this PR about?

This was being caused by the nested `forEach` loops in bot.js
[here](https://github.com/shaunburdick/slack-ooo/blob/cd6a4e59734f8ee9779d59f37a9f1b2c4126caad/lib/bot.js#L192-L208)
## More info/screenshots, etc.

Example of double messages that were being sent. Sorry I don't know why this didn't catch my eye yesterday -- I guess I was more concerned about the bot posting the message.

<img width="532" alt="screen shot 2016-09-16 at 11 17 52 pm" src="https://cloud.githubusercontent.com/assets/13568167/18599999/db9252e0-7c63-11e6-8e30-c55d3edd9136.png">

<img width="670" alt="screen shot 2016-09-16 at 11 17 39 pm" src="https://cloud.githubusercontent.com/assets/13568167/18600000/db98d962-7c63-11e6-85dd-27eb78a83c28.png">

<img width="755" alt="screen shot 2016-09-16 at 11 16 36 pm" src="https://cloud.githubusercontent.com/assets/13568167/18599960/b02be382-7c63-11e6-9816-c52aeaa2eaae.png">

Also includes a fix **to loop over only valid channels**, for instance I tried this on the config:

``` javascript
channels: ['ooo', 'general', 'null']
```

Channel `null` does not exist, so got this on the console log. However, it fails silently as opposed to crashing:
<img width="720" alt="screen shot 2016-09-17 at 1 22 47 am" src="https://cloud.githubusercontent.com/assets/13568167/18603008/8d676e80-7c76-11e6-8b36-e7d210024083.png">

The last fix - dc16343 address this.
